### PR TITLE
Additional infromation for CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,25 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(
-  FastNoise
-  VERSION 0.4
-  LANGUAGES CXX)
+project(FastNoise VERSION 0.4 LANGUAGES CXX)
 
 add_library(${PROJECT_NAME} FastNoise.cpp)
 
-target_compile_options(
-  ${PROJECT_NAME}
-  PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
-          -Wall
-          -Wextra
-          -pedantic
-          -Wno-implicit-fallthrough
-          -Wno-unused-parameter
-          -Wno-unused-function>
-          $<$<CXX_COMPILER_ID:MSVC>:
-          /W4
-          /w14640>)
+target_compile_options(${PROJECT_NAME} PRIVATE
+        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
+        -Wall
+        -Wextra
+        -pedantic
+        -Wno-implicit-fallthrough
+        -Wno-unused-parameter
+        -Wno-unused-function>
+        $<$<CXX_COMPILER_ID:MSVC>:
+        /W4
+        /w14640>
+        )
 
-set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17
-                                                 CXX_STANDARD_REQUIRED ON)
+set_target_properties(
+        ${PROJECT_NAME} PROPERTIES
+        CXX_STANDARD 17
+        CXX_STANDARD_REQUIRED ON
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,29 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(FastNoise VERSION 0.4 LANGUAGES CXX)
+project(
+  FastNoise
+  VERSION 0.4
+  LANGUAGES CXX)
 
 add_library(${PROJECT_NAME} FastNoise.cpp)
+target_include_directories(${PROJECT_NAME}
+                           INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_compile_options(${PROJECT_NAME} PRIVATE
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
-        -Wall
-        -Wextra
-        -pedantic
-        -Wno-implicit-fallthrough
-        -Wno-unused-parameter
-        -Wno-unused-function>
-        $<$<CXX_COMPILER_ID:MSVC>:
-        /W4
-        /w14640>
-        )
+target_compile_options(
+  ${PROJECT_NAME}
+  PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
+          -Wall
+          -Wextra
+          -pedantic
+          -Wno-implicit-fallthrough
+          -Wno-unused-parameter
+          -Wno-unused-function>
+          $<$<CXX_COMPILER_ID:MSVC>:
+          /W4
+          /w14640>)
 
-set_target_properties(
-        ${PROJECT_NAME} PROPERTIES
-        CXX_STANDARD 17
-        CXX_STANDARD_REQUIRED ON
-)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17
+                                                 CXX_STANDARD_REQUIRED ON)
 
+install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+install(FILES FastNoise.h DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,24 +1,24 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(FastNoise)
+project(
+  FastNoise
+  VERSION 0.4
+  LANGUAGES CXX)
 
 add_library(${PROJECT_NAME} FastNoise.cpp)
 
-target_compile_options(${PROJECT_NAME} PRIVATE
-        $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
-        -Wall
-        -Wextra
-        -pedantic
-        -Wno-implicit-fallthrough
-        -Wno-unused-parameter
-        -Wno-unused-function>
-        $<$<CXX_COMPILER_ID:MSVC>:
-        /W4
-        /w14640>
-        )
+target_compile_options(
+  ${PROJECT_NAME}
+  PRIVATE $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:GNU>>:
+          -Wall
+          -Wextra
+          -pedantic
+          -Wno-implicit-fallthrough
+          -Wno-unused-parameter
+          -Wno-unused-function>
+          $<$<CXX_COMPILER_ID:MSVC>:
+          /W4
+          /w14640>)
 
-set_target_properties(
-        ${PROJECT_NAME} PROPERTIES
-        CXX_STANDARD 17
-        CXX_STANDARD_REQUIRED ON
-)
+set_target_properties(${PROJECT_NAME} PROPERTIES CXX_STANDARD 17
+                                                 CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
CMake defaults to checking for both the C and C++ compilers. If the language is specified in the project call, we skipp the check for compilers we don't actually need. I activated C++ (and therefore disabled C) for the project.

Adding a version number is good practice.